### PR TITLE
Fixed podfile instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Ziggeo API (http://ziggeo.com) allows you to integrate video recording and playb
   ```
 - Add framework to Podfile
   ```
-  pod 'ZiggeoSwiftSDK', '1.0.0'
+  pod 'ZiggeoSwiftSDK', :git => 'https://github.com/Ziggeo/Swift-Client-SDK.git', :branch => '1.0.0'
   ```
 - Install framework
   ```


### PR DESCRIPTION
The old instruction: `pod 'ZiggeoSwiftSDK', '1.0.0'` returned the following error when `pod install` was run: '[!] Unable to find a specification for'.

The new instruction runs fine, I am using the framework in Xcode without any problems after running `pod install` with the proposed new instruction.

I am not an expert so I don't know whether there is a better way of fixing this problem but my solution appears to work fine.

Thanks,
Tom Fox